### PR TITLE
fix: use RestOptions over deprecated WebOptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .gradle/
 build/
+.idea

--- a/src/main/java/com/github/knaufk/flinkjunit/FlinkJUnitRuleBuilder.java
+++ b/src/main/java/com/github/knaufk/flinkjunit/FlinkJUnitRuleBuilder.java
@@ -78,7 +78,7 @@ public final class FlinkJUnitRuleBuilder {
     config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, noOfTaskmanagers);
     config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, noOfTaskSlots);
     config.setBoolean(ConfigConstants.LOCAL_START_WEBSERVER, webUiEnabled);
-    config.setInteger(RestOptions.PORT, webUiPort);
+    config.setInteger(RestOptions.REST_PORT, webUiPort);
 
     config.setInteger(
         TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY, DEFAULT_TASK_MANAGER_MEMORY_SIZE);

--- a/src/main/java/com/github/knaufk/flinkjunit/FlinkJUnitRuleBuilder.java
+++ b/src/main/java/com/github/knaufk/flinkjunit/FlinkJUnitRuleBuilder.java
@@ -78,7 +78,7 @@ public final class FlinkJUnitRuleBuilder {
     config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, noOfTaskmanagers);
     config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, noOfTaskSlots);
     config.setBoolean(ConfigConstants.LOCAL_START_WEBSERVER, webUiEnabled);
-    config.setInteger(WebOptions.PORT, webUiPort);
+    config.setInteger(RestOptions.PORT, webUiPort);
 
     config.setInteger(
         TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY, DEFAULT_TASK_MANAGER_MEMORY_SIZE);


### PR DESCRIPTION
From the source:
` * @deprecated Use {@link RestOptions#PORT} instead `

Looks like Flink 1.4 uses `RestOptions.REST_PORT` instead. Any plans to upgrade the Flink version?
